### PR TITLE
Update TwitchLib packages, removed old event overrides from PubSub and Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # Files used to weave for NuGet
 TwitchLib/FodyWeavers.xml
 TwitchLib/packages.config
+TwitchLib.Unity/FodyWeavers.xml
+TwitchLib.Unity/FodyWeavers.xsd
 
 # User-specific files
 *.suo

--- a/TwitchLib.Unity/Client.cs
+++ b/TwitchLib.Unity/Client.cs
@@ -11,8 +11,6 @@ namespace TwitchLib.Unity
 {
     public class Client : TwitchClient, ITwitchClient
     {
-        public new bool OverrideBeingHostedCheck { get; set; }
-        
         #region Events
         /// <summary>
         /// Fires whenever a log write happens.
@@ -110,11 +108,6 @@ namespace TwitchLib.Unity
         public new event EventHandler<OnContinuedGiftedSubscriptionArgs> OnContinuedGiftedSubscription;
 
         /// <summary>
-        /// Fires when a hosted streamer goes offline and hosting is killed.
-        /// </summary>
-        public new event EventHandler OnHostLeft;
-
-        /// <summary>
         /// Fires when Twitch notifies client of existing users in chat.
         /// </summary>
         public new event EventHandler<OnExistingUsersDetectedArgs> OnExistingUsersDetected;
@@ -123,16 +116,6 @@ namespace TwitchLib.Unity
         /// Fires when a PART message is received from Twitch regarding a particular viewer
         /// </summary>
         public new event EventHandler<OnUserLeftArgs> OnUserLeft;
-
-        /// <summary>
-        /// Fires when the joined channel begins hosting another channel.
-        /// </summary>
-        public new event EventHandler<OnHostingStartedArgs> OnHostingStarted;
-
-        /// <summary>
-        /// Fires when the joined channel quits hosting another channel.
-        /// </summary>
-        public new event EventHandler<OnHostingStoppedArgs> OnHostingStopped;
 
         /// <summary>
         /// Fires when bot has disconnected.
@@ -180,16 +163,6 @@ namespace TwitchLib.Unity
         public new event EventHandler<OnSendReceiveDataArgs> OnSendReceiveData;
 
         /// <summary>
-        /// Fires when client receives notice that a joined channel is hosting another channel.
-        /// </summary>
-        public new event EventHandler<OnNowHostingArgs> OnNowHosting;
-
-        /// <summary>
-        /// Fires when the library detects another channel has started hosting the broadcaster's stream. MUST BE CONNECTED AS BROADCASTER.
-        /// </summary>
-        public new event EventHandler<OnBeingHostedArgs> OnBeingHosted;
-
-        /// <summary>
         /// Fires when a raid notification is detected in chat
         /// </summary>
         public new event EventHandler<OnRaidNotificationArgs> OnRaidNotification;
@@ -207,9 +180,6 @@ namespace TwitchLib.Unity
 
         /// <summary>Fires when newly raided channel is mature audience only.</summary>
         public new event EventHandler OnRaidedChannelIsMatureAudience;
-
-        /// <summary>Fires when a ritual for a new chatter is received.</summary>
-        public new event EventHandler<OnRitualNewChatterArgs> OnRitualNewChatter;
 
         /// <summary>Fires when the client was unable to join a channel.</summary>
         public new event EventHandler<OnFailureToReceiveJoinConfirmationArgs> OnFailureToReceiveJoinConfirmation;
@@ -237,18 +207,12 @@ namespace TwitchLib.Unity
         {
             ThreadDispatcher.EnsureCreated();
 
-            base.OverrideBeingHostedCheck = true;
-
             base.OnLog += (object sender, OnLogArgs e) => { ThreadDispatcher.Enqueue(() => OnLog?.Invoke(sender, e)); };
             base.OnConnected += ((object sender, OnConnectedArgs e) => { ThreadDispatcher.Enqueue(() => OnConnected?.Invoke(sender, e)); });
 
             base.OnJoinedChannel += ((object sender, OnJoinedChannelArgs e) => {
 
                 ThreadDispatcher.Enqueue(() => OnJoinedChannel?.Invoke(sender, e));
-
-                if (OnBeingHosted == null) return;
-                if (e.Channel.ToLower() != TwitchUsername && !OverrideBeingHostedCheck)
-                    ThreadDispatcher.Enqueue(() => throw new BadListenException("BeingHosted", "You cannot listen to OnBeingHosted unless you are connected to the broadcaster's channel as the broadcaster. You may override this by setting the TwitchClient property OverrideBeingHostedCheck to true."));
             });
 
             base.OnIncorrectLogin += ((object sender, OnIncorrectLoginArgs e) => { ThreadDispatcher.Enqueue(() => OnIncorrectLogin?.Invoke(sender, e)); });
@@ -267,11 +231,8 @@ namespace TwitchLib.Unity
             base.OnReSubscriber += ((object sender, OnReSubscriberArgs e) => { ThreadDispatcher.Enqueue(() => OnReSubscriber?.Invoke(sender, e)); });
             base.OnPrimePaidSubscriber += ((object sender, OnPrimePaidSubscriberArgs e) => { ThreadDispatcher.Enqueue(() => OnPrimePaidSubscriber?.Invoke(sender, e)); });
             base.OnContinuedGiftedSubscription += ((object sender, OnContinuedGiftedSubscriptionArgs e) => { ThreadDispatcher.Enqueue(() => OnContinuedGiftedSubscription?.Invoke(sender, e)); });
-            base.OnHostLeft += ((object sender, EventArgs arg) => { ThreadDispatcher.Enqueue(() => OnHostLeft?.Invoke(sender, arg)); });
             base.OnExistingUsersDetected += ((object sender, OnExistingUsersDetectedArgs e) => { ThreadDispatcher.Enqueue(() => OnExistingUsersDetected?.Invoke(sender, e)); });
             base.OnUserLeft += ((object sender, OnUserLeftArgs e) => { ThreadDispatcher.Enqueue(() => OnUserLeft?.Invoke(sender, e)); });
-            base.OnHostingStarted += ((object sender, OnHostingStartedArgs e) => { ThreadDispatcher.Enqueue(() => OnHostingStarted?.Invoke(sender, e)); });
-            base.OnHostingStopped += ((object sender, OnHostingStoppedArgs e) => { ThreadDispatcher.Enqueue(() => OnHostingStopped?.Invoke(sender, e)); });
             base.OnDisconnected += ((object sender, OnDisconnectedEventArgs e) => { ThreadDispatcher.Enqueue(() => OnDisconnected?.Invoke(sender, e)); });
             base.OnConnectionError += ((object sender, OnConnectionErrorArgs e) => { ThreadDispatcher.Enqueue(() => OnConnectionError?.Invoke(sender, e)); });
             base.OnChatCleared += ((object sender, OnChatClearedArgs e) => { ThreadDispatcher.Enqueue(() => OnChatCleared?.Invoke(sender, e)); });
@@ -281,12 +242,9 @@ namespace TwitchLib.Unity
             base.OnModeratorsReceived += ((object sender, OnModeratorsReceivedArgs e) => { ThreadDispatcher.Enqueue(() => OnModeratorsReceived?.Invoke(sender, e)); });
             base.OnChatColorChanged += ((object sender, OnChatColorChangedArgs e) => { ThreadDispatcher.Enqueue(() => OnChatColorChanged?.Invoke(sender, e)); });
             base.OnSendReceiveData += ((object sender, OnSendReceiveDataArgs e) => { ThreadDispatcher.Enqueue(() => OnSendReceiveData?.Invoke(sender, e)); });
-            base.OnNowHosting += ((object sender, OnNowHostingArgs e) => { ThreadDispatcher.Enqueue(() => OnNowHosting?.Invoke(sender, e)); });
-            base.OnBeingHosted += ((object sender, OnBeingHostedArgs e) => { ThreadDispatcher.Enqueue(() => OnBeingHosted?.Invoke(sender, e)); });
             base.OnRaidNotification += ((object sender, OnRaidNotificationArgs e) => { ThreadDispatcher.Enqueue(() => OnRaidNotification?.Invoke(sender, e)); });
             base.OnGiftedSubscription += ((object sender, OnGiftedSubscriptionArgs e) => { ThreadDispatcher.Enqueue(() => OnGiftedSubscription?.Invoke(sender, e)); });
             base.OnRaidedChannelIsMatureAudience += ((object sender, EventArgs arg) => { ThreadDispatcher.Enqueue(() => OnRaidedChannelIsMatureAudience?.Invoke(sender, arg)); });
-            base.OnRitualNewChatter += ((object sender, OnRitualNewChatterArgs e) => { ThreadDispatcher.Enqueue(() => OnRitualNewChatter?.Invoke(sender, e)); });
             base.OnFailureToReceiveJoinConfirmation += ((object sender, OnFailureToReceiveJoinConfirmationArgs e) => { ThreadDispatcher.Enqueue(() => OnFailureToReceiveJoinConfirmation?.Invoke(sender, e)); });
             base.OnUnaccountedFor += ((object sender, OnUnaccountedForArgs e) => { ThreadDispatcher.Enqueue(() => OnUnaccountedFor?.Invoke(sender, e)); });
             base.OnSelfRaidError += ((object sender, EventArgs e) => { ThreadDispatcher.Enqueue(() => OnSelfRaidError?.Invoke(sender, e)); });

--- a/TwitchLib.Unity/PubSub.cs
+++ b/TwitchLib.Unity/PubSub.cs
@@ -55,8 +55,6 @@ namespace TwitchLib.Unity
         /// <summary>EventHandler for channel subscriptions.</summary>
         public new event EventHandler<OnChannelSubscriptionArgs> OnChannelSubscription;
         /// <summary>EventHandler for named event.</summary>
-        public new event EventHandler<OnChannelCommerceReceivedArgs> OnChannelCommerceReceived;
-        /// <summary>EventHandler for named event.</summary>
         public new event EventHandler<OnChannelExtensionBroadcastArgs> OnChannelExtensionBroadcast;
         /// <summary>EventHandler for named event.</summary>
         public new event EventHandler<OnFollowArgs> OnFollow;
@@ -122,7 +120,6 @@ namespace TwitchLib.Unity
             base.OnViewCount += ((object sender, OnViewCountArgs e) => { ThreadDispatcher.Enqueue(() => OnViewCount?.Invoke(sender, e)); });
             base.OnWhisper += ((object sender, OnWhisperArgs e) => { ThreadDispatcher.Enqueue(() => OnWhisper?.Invoke(sender, e)); });
             base.OnChannelSubscription += ((object sender, OnChannelSubscriptionArgs e) => { ThreadDispatcher.Enqueue(() => OnChannelSubscription?.Invoke(sender, e)); });
-            base.OnChannelCommerceReceived += ((object sender, OnChannelCommerceReceivedArgs e) => { ThreadDispatcher.Enqueue(() => OnChannelCommerceReceived?.Invoke(sender, e)); });
             base.OnChannelExtensionBroadcast += ((object sender, OnChannelExtensionBroadcastArgs e) => { ThreadDispatcher.Enqueue(() => OnChannelExtensionBroadcast?.Invoke(sender, e)); });
             base.OnFollow += ((object sender, OnFollowArgs e) => { ThreadDispatcher.Enqueue(() => OnFollow?.Invoke(sender, e)); });
             base.OnCustomRewardCreated += ((object sender, OnCustomRewardCreatedArgs e) => { ThreadDispatcher.Enqueue(() => OnCustomRewardCreated?.Invoke(sender, e)); });

--- a/TwitchLib.Unity/TwitchLib.Unity.csproj
+++ b/TwitchLib.Unity/TwitchLib.Unity.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.Unity</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <Copyright>Copyright 2021</Copyright>
-    <PackageReleaseNotes>Version bumps for Unity to match latest dev branch of TwitchLib.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updates to packages and removed outdated code</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/TwitchLib/TwitchLib.Unity</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library unity3d unity dotnet c# csharp net standard 2.0</PackageTags>
@@ -42,14 +42,14 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="5.0.0-beta0001">
+    <PackageReference Include="Costura.Fody" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="TwitchLib.Api" Version="3.2.5-preview-9a3c9a73b72f479e1c27fec4e1c7ec77dd69f125" />
-    <PackageReference Include="TwitchLib.Client" Version="3.2.3" />
-    <PackageReference Include="TwitchLib.PubSub" Version="3.2.3" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="TwitchLib.Api" Version="3.9.0" />
+    <PackageReference Include="TwitchLib.Client" Version="3.3.1" />
+    <PackageReference Include="TwitchLib.PubSub" Version="3.2.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated all packages to the latest:
- Costura.Fody -> 5.7.0
- Serilog.Extensions.Logging -> 3.1.0
- TwitchLib.Api -> 3.9.0
-  TwitchLib.Client -> 3.3.1
- TwitchLib.PubSub -> 3.2.6

Mainly updated so I could get Predictions statuses from GetPredictions (which is now GetPredictionsAsync), so nothing new was added, just updated packages and removed any code which was causing errors (things which were removed or changed in TwitchLib, for example RitualNewChatter)

Tested in Unity 2023.1.0b9 and works as expected.

